### PR TITLE
Issue #38 - Update the Login Message String to show a custom message and not the name of the FileMaker File being signed into

### DIFF
--- a/src/WebDLanding/Models/AppModel.cs
+++ b/src/WebDLanding/Models/AppModel.cs
@@ -17,4 +17,5 @@ public class AppModel
         uriString: $"{WebDirectHostScheme}://{WebDirectHostName}/fmi/webd/{DatabaseName}"
     );
 
+    public string? LoginHeaderMessage { get; set; }
 }

--- a/src/WebDLanding/Program.cs
+++ b/src/WebDLanding/Program.cs
@@ -47,6 +47,7 @@ try
             ? $"{model.EntryHostScheme}://{model.EntryHostName}"
             : $"{siteSettings.WebdLandingMainUrl}";
         jsToWrite += $"let homeUri = '{homeUri}';";
+        jsToWrite += $"let loginHeaderMessage = '{model.LoginHeaderMessage ?? ""};";
 
         context.Response.ContentType = "application/javascript; charset=utf-8";
         await context.Response.WriteAsync(jsToWrite);

--- a/src/WebDLanding/Program.cs
+++ b/src/WebDLanding/Program.cs
@@ -47,7 +47,7 @@ try
             ? $"{model.EntryHostScheme}://{model.EntryHostName}"
             : $"{siteSettings.WebdLandingMainUrl}";
         jsToWrite += $"let homeUri = '{homeUri}';";
-        jsToWrite += $"let loginHeaderMessage = '{model.LoginHeaderMessage ?? ""};";
+        jsToWrite += $"let loginHeaderMessage = '{model.LoginHeaderMessage ?? ""}';";
 
         context.Response.ContentType = "application/javascript; charset=utf-8";
         await context.Response.WriteAsync(jsToWrite);

--- a/src/WebDLanding/wwwroot/webdlanding.js
+++ b/src/WebDLanding/wwwroot/webdlanding.js
@@ -28,9 +28,23 @@ window.addEventListener("popstate", function () {
   }
 });
 
+function setHeaderMessage() {
+  let msg = document
+    .getElementsByTagName('iframe')[0]
+    .contentDocument.getElementById('login_header_msg');
+
+  if (msg && loginHeaderMessage) {
+    // load message from AppModel.
+    msg.innerHTML = loginHeaderMessage;
+  } else {
+    setTimeout(setHeaderMessage, 200);
+  }
+}
+
 iframe = document.getElementById("webdirect-frame");
 iframe.addEventListener("load", function () {
   history.pushState(null, null, "");
+  setHeaderMessage();
 });
 
 window.addEventListener("load", function () {

--- a/src/WebDLanding/wwwroot/webdlanding.js
+++ b/src/WebDLanding/wwwroot/webdlanding.js
@@ -30,8 +30,8 @@ window.addEventListener("popstate", function () {
 
 function setHeaderMessage() {
   let msg = document
-    .getElementsByTagName('iframe')[0]
-    .contentDocument.getElementById('login_header_msg');
+    .getElementById("webdirect-frame")
+    ?.contentDocument?.getElementById('login_header_msg');
 
   if (msg && loginHeaderMessage) {
     // load message from AppModel.


### PR DESCRIPTION
- Add the login header message to the AppModel
- Replace the text of the file being opened with that login header message
- Wait until the page is loaded to replace that message